### PR TITLE
Add configurable getDefaultProps method :sparkles:

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Props validations and the validators themselves are all provided by the
 ember install ember-cli-prop-types
 ```
 
-## Usage
+## Props Validation
 Import `PropTypes` into your component JS files and define a `propTypes` property to
 perform validation on passed props:
 
@@ -67,17 +67,56 @@ export default Component.extend({
 });
 ```
 
-#### Using didReceiveAttrs
-This addon calls the props validation method in the `didReceiveAttrs` hook of dev
-builds. Per the Ember.js docs, if you need to define additional behavior called in
-`didReceiveAttrs` you must call `this._super(...arguments)`:
+## Props Default Values
+This addon adds the ability to set a default value for passed props through a `getDefaultProps`
+method. This method should return an object with the default props values:
+
+```javascript
+import Component from 'ember-component';
+import { string, number, bool } from 'prop-types';
+
+export default Component.extend({
+  propTypes: {
+    title: string.isRequired,
+    pages: number,
+    isLatest: bool
+  },
+  getDefaultProps() {
+    return {
+      title: 'Ambitious Props',
+      pages: 1,
+      isLatest: false
+    };
+  }
+});
+```
+
+During component initialization, if a prop with a configured default is `undefined`,
+it will be set to the returned default value. This can be especially helpful when
+working with dynamic values or the component helper.
+
+The `getDefaultProps` method is run during production builds.
+
+## Lifecycle Hook Super Calls
+This addon calls props validation and default value assignments in the `didReceiveAttrs`
+and `init` lifecycle hooks. Per the Ember.js docs, if you need to define additional behavior in
+these hooks you must call `this._super(...arguments)`:
 
 ```javascript
 export default Component.extend({
   propTypes: {
     someString: PropTypes.string
   },
+  getDefaultProps() {
+    return {
+      someString: 'Default Value'
+    }
+  },
 
+  init() {
+    this._super(...arguments);
+    // your component code
+  },
   didReceiveAttrs() {
     this._super(...arguments);
     // your component code
@@ -96,14 +135,19 @@ The call to `PropTypes.checkPropTypes` is automatically stripped in production b
 as well using UglifyJS's `compress` configurations. If you would like to disable this
 additional stripping you can configure the addon to skip it in your
 `ember-cli-build.js` configs _(Note that even if you disable the code stripping props
-validations will still only be run in dev builds).
+validations will still only be run in dev builds)_.
+
+The `getDefaultProps` method is run during component `init` in production builds. If
+you would prefer not to enable this method, you can configure the addon to strip it
+out:
 
 ```javascript
 // ember-cli-build.js
 module.exports = function(defaults) {
   let app = new EmberApp(defaults, {
     emberCliPropTypes: {
-      compress: false
+      compress: false, // Setting to false will disable code stripping
+      getDefaultProps: false // Setting to false will strip `getDefaultProps` feature
     }
   });
 

--- a/addon/initializers/component-prop-types.js
+++ b/addon/initializers/component-prop-types.js
@@ -2,27 +2,54 @@ import Component from 'ember-component';
 import { checkPropTypes } from 'prop-types';
 
 /**
- * Reopen the Component class and add props validation checking the `didReceiveAttrs`
- * hook with `checkPropTypes` utility method exported by `prop-types`.
+ * Initializer is optimized for production using injected process.env variables.
+ * These are either added to the window as globals during dev builds or injected into
+ * the build using UglifyJS during production builds.
  */
 function initialize() {
-  // Strip out the props validation in production environments
+  let propTypesExtends = {};
+
+  // Props validation included in dev only
+  // Add props validation checking during `didReceiveAttrs` hook with
+  // `checkPropTypes` utility method
   if (process.env.NODE_ENV === 'development') {
-    Component.reopen({
-      didReceiveAttrs() {
-        this._super(...arguments);
+    propTypesExtends.didReceiveAttrs = function() {
+      this._super(...arguments);
 
-        const propTypes = this.get('propTypes') || {};
+      const propTypes = this.get('propTypes') || {};
 
-        // prop-types can handle calling `checkPropTypes` without any props, always call
-        checkPropTypes(
-          propTypes, // PropTypes definition
-          this.getProperties(...Object.keys(propTypes)), // Values to validate
-          'prop', // Type of validation that is occuring
-          this.toString() // Name of component for better debug messaging
-        );
+      // prop-types can handle calling `checkPropTypes` without any props, always call
+      checkPropTypes(
+        propTypes, // PropTypes definition
+        this.getProperties(...Object.keys(propTypes)), // Values to validate
+        'prop', // Type of validation that is occuring
+        this.toString() // Name of component for better debug messaging
+      );
+    };
+  }
+
+  // Default Props included by default, can be configured off
+  // Sets a default value for props during component initialization if undefined or
+  // null
+  if (process.env.INCLUDE_GET_DEFAULT_PROPS) {
+    propTypesExtends.init = function() {
+      this._super(...arguments);
+      // If default props are not configured, we're done
+      if (!this.get('getDefaultProps')) { return; }
+      let defaultProps = this.get('getDefaultProps')();
+
+      // If any prop with a default is undefined (undefined only), assign default
+      // value to prop. Do not set default for null, undefined means a variable has
+      // not been declared, null means a variable has been set to null.
+      for (let prop in defaultProps) {
+        if (this.get(prop) === undefined) { this.set(prop, defaultProps[prop]); }
       }
-    });
+    };
+  }
+
+  // Only reopen Component class if adding props validation or getDefaultProps method
+  if (process.env.NODE_ENV === 'development' || process.env.INCLUDE_GET_DEFAULT_PROPS) {
+    Component.reopen(propTypesExtends);
   }
 }
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,10 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
     // Add options here
+    emberCliPropTypes: {
+      // compress: false,
+      // getDefaultProps: false
+    }
   });
 
   /*

--- a/tests/dummy/app/components/default-props.js
+++ b/tests/dummy/app/components/default-props.js
@@ -1,0 +1,17 @@
+import Component from 'ember-component';
+import hbs from 'htmlbars-inline-precompile';
+
+export default Component.extend({
+
+  getDefaultProps() {
+    return {
+      content: 'When passing dynamic data, it can be helpful to have a default value for some prop.'
+    };
+  },
+
+  layout: hbs`
+    <p>
+      {{content}}
+    </p>
+  `
+});

--- a/tests/dummy/app/components/warning-test.js
+++ b/tests/dummy/app/components/warning-test.js
@@ -5,7 +5,7 @@ import { bool, number, string } from 'prop-types';
 export default Component.extend({
   propTypes: {
     someString: string,
-    someNumber: number,
+    someNumber: number.isRequired,
     someBool: bool
   },
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,4 +1,5 @@
-{{warning-test someString='5' someNumber=5}}
+{{warning-test someString='5'}}
 {{no-props}}
-{{required-props}}
+{{default-props}}
+{{required-props name='prop-types'}}
 {{outlet}}


### PR DESCRIPTION
Resolve #4 

Adds `getDefaultProps` method run during component `init` hook.

Any undefined prop with a configured default will have that default assigned.