### PR TITLE
Adds `export` to component-prop-types initializer fn

### DIFF
--- a/addon/initializers/component-prop-types.js
+++ b/addon/initializers/component-prop-types.js
@@ -7,7 +7,7 @@ const { checkPropTypes } = PropTypes;
  * These are either added to the window as globals during dev builds or injected into
  * the build using UglifyJS during production builds.
  */
-function initialize() {
+export function initialize() {
   let propTypesExtends = {};
 
   // Props validation included in dev only


### PR DESCRIPTION
Looking to import `initialize()` into integration tests to run default props.